### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to NeuraFix
+
+Thank you for your interest in contributing to **NeuraFix**! We welcome contributions from everyone. Here's how you can help:
+
+## How to Contribute
+
+1. **Fork the Repository**
+   - Click on the `Fork` button at the top of the page to create a copy of the repository in your account.
+
+2. **Clone Your Fork**
+   - Clone the forked repository to your local system:
+     ```bash
+     git clone https://github.com/your-username/NeuraFix.git
+     cd NeuraFix
+     ```
+
+3. **Create a Branch**
+   - Create a new branch for your changes:
+     ```bash
+     git checkout -b feature/your-feature-name
+     ```
+
+4. **Make Changes**
+   - Add your changes or improvements.
+
+5. **Test Your Changes**
+   - Ensure your changes work as intended and don't break anything.
+
+6. **Commit and Push**
+   - Commit your changes:
+     ```bash
+     git add .
+     git commit -m "Describe your changes"
+     git push origin feature/your-feature-name
+     ```
+
+7. **Create a Pull Request**
+   - Go to the original repository and click on `Compare & pull request`.
+   - Provide a clear description of your changes and submit your pull request.
+
+## Guidelines
+- Ensure your code adheres to the coding style used in this project.
+- Document any new features or updates.
+- Be respectful and inclusive when discussing issues or reviewing code.
+
+## Issues
+If you find a bug or have a feature request, feel free to open an issue in the repository.
+
+---
+
+Thank you for contributing to NeuraFix!


### PR DESCRIPTION
he CONTRIBUTING.md file is typically used in open-source projects to guide contributors on how they can participate. If you're getting a "404 - page not found" error on your repository for this file, it means the file doesn't exist yet in the repository's main branch. Here's how you can fix it:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Contributing to NeuraFix" section in the documentation, providing a comprehensive guide for potential contributors.
- **Documentation**
	- Added guidelines for contributing, including steps for forking, branching, testing, and submitting changes, along with coding style and communication expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->